### PR TITLE
Fix Flash command in documentation

### DIFF
--- a/website/docs/installation.md
+++ b/website/docs/installation.md
@@ -84,7 +84,7 @@ unxz -T 0 ~/Downloads/ubuntu-20.04-preinstalled-server-arm64+raspi.img.xz
 
 ```bash
 flash \
-    --userdata setup/cloud-config.yml \
+    --config setup/cloud-config.yml \
     ~/Downloads/ubuntu-20.04-preinstalled-server-arm64+raspi.img
 ```
 


### PR DESCRIPTION
# Description

Fixes the Flash command to use the correct option for the cloud-config yaml.

## Type Of Change

- [x] Docs
- [ ] Installation
- [ ] Performance and Scalability
- [ ] Security
- [ ] Test and/or Release
- [ ] User Experience

Fixes #31 