### PR TITLE
Fix Ubuntu download link

### DIFF
--- a/website/docs/installation.md
+++ b/website/docs/installation.md
@@ -76,8 +76,8 @@ sudo chmod +x /usr/local/bin/flash
 Follow the following command to download `ubuntu-20.04` image and extract it.
 
 ```bash
-curl -L "http://cdimage.ubuntu.com/releases/focal/release/ubuntu-20.04-preinstalled-server-arm64+raspi.img.xz" -o ~/Downloads/ubuntu-20.04-preinstalled-server-arm64+raspi.img.xz
-unxz -T 0 ~/Downloads/ubuntu-20.04-preinstalled-server-arm64+raspi.img.xz
+curl -L "http://cdimage.ubuntu.com/releases/focal/release/ubuntu-20.04.1-preinstalled-server-arm64+raspi.img.xz" -o ~/Downloads/ubuntu-20.04.1-preinstalled-server-arm64+raspi.img.xz
+unxz -T 0 ~/Downloads/ubuntu-20.04.1-preinstalled-server-arm64+raspi.img.xz
 ```
 
 #### Flash
@@ -85,7 +85,7 @@ unxz -T 0 ~/Downloads/ubuntu-20.04-preinstalled-server-arm64+raspi.img.xz
 ```bash
 flash \
     --userdata setup/cloud-config.yml \
-    ~/Downloads/ubuntu-20.04-preinstalled-server-arm64+raspi.img
+    ~/Downloads/ubuntu-20.04.1-preinstalled-server-arm64+raspi.img
 ```
 
 #### Boot


### PR DESCRIPTION
# Description

A new release of the image used in the documentation has been released
and the old one has been removed causing us to get a 404 with the link
that was in the documentation.

Updating to the new image to fix the docs.

## Type Of Change

To help us figure out who should review this PR, please put an X in all the areas that this PR affects.

- [x] Docs
- [ ] Installation
- [ ] Performance and Scalability
- [ ] Security
- [ ] Test and/or Release
- [ ] User Experience

Fixes #33 