### PR TITLE
Add Single-Quotes to EOF to disable interpolation

### DIFF
--- a/website/docs/usb-booting.md
+++ b/website/docs/usb-booting.md
@@ -146,7 +146,7 @@ cp ~/vmlinux /media/pi/system-boot/
 Next create a script that will automatically decompress the kernel so that we can reboot the Pi without having to do the previous steps manually every boot:
 
 ```bash
-cat <<EOF >/media/pi/system-boot/auto_decompress_kernel
+cat <<'EOF' >/media/pi/system-boot/auto_decompress_kernel
 #!/bin/bash -e
 
 #Set Variables
@@ -195,12 +195,6 @@ fi
 #Exit
 exit 0
 EOF
-```
-
-Make the script executeable:
-
-```bash
-sudo chmod +x /media/pi/system-boot/auto_decompress_kernel
 ```
 
 Create an `apt` hook that decompresses the kernel on updates:


### PR DESCRIPTION
# Description

* disables interpolation from bash/shell when using the EOF for the /boot/firmware/auto_decompress_kernel script
* removes the unnecessary chmod to the /boot/firmware/auto_decompress_kernel file (/boot is a FAT32 partition)

## Type Of Change

To help us figure out who should review this PR, please put an X in all the areas that this PR affects.

- [x] Docs
- [ ] Installation
- [ ] Performance and Scalability
- [ ] Security
- [ ] Test and/or Release
- [ ] User Experience

## Issue Ref (Optional)

Which issue(s) this PR fixes (optional, using fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when the PR gets merged): Fixes #

## Notes

Add special notes for your reviewer here.
